### PR TITLE
allow format to start with a new line

### DIFF
--- a/.README/rules/format.md
+++ b/.README/rules/format.md
@@ -15,6 +15,7 @@ The first option is an object with the following configuration.
 |`ignoreExpressions`|boolean|`false`|Does not format template literals that contain expressions.|
 |`ignoreInline`|boolean|`true`|Does not format queries that are written on a single line.|
 |`ignoreTagless`|boolean|`true`|Does not format queries that are written without using `sql` tag.|
+|`ignoreStartWithNewLine`|boolean|`true`|Does not remove `\n` at the beginning of queries.|
 
 The second option is an object with the [`pg-formatter` configuration](https://github.com/gajus/pg-formatter#configuration).
 

--- a/README.md
+++ b/README.md
@@ -172,9 +172,8 @@ The `sql` tag can be anything, e.g.
 
 * https://github.com/seegno/sql-tag
 * https://github.com/gajus/mightyql#tagged-template-literals
-* https://github.com/nearform/sql
 
-<a name="eslint-plugin-sql-rules-no-unsafe-query-options"></a>
+<a name="eslint-plugin-sql-rules-no-unsafe-query-options-1"></a>
 #### Options
 
 The first option is an object with the following configuration.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The first option is an object with the following configuration.
 |`ignoreExpressions`|boolean|`false`|Does not format template literals that contain expressions.|
 |`ignoreInline`|boolean|`true`|Does not format queries that are written on a single line.|
 |`ignoreTagless`|boolean|`true`|Does not format queries that are written without using `sql` tag.|
+|`ignoreStartWithNewLine`|boolean|`true`|Does not remove `\n` at the beginning of queries.|
 
 The second option is an object with the [`pg-formatter` configuration](https://github.com/gajus/pg-formatter#configuration).
 

--- a/src/rules/format.js
+++ b/src/rules/format.js
@@ -16,6 +16,7 @@ export default (context) => {
   const ignoreExpressions = pluginOptions.ignoreExpressions === true;
   const ignoreInline = pluginOptions.ignoreInline !== false;
   const ignoreTagless = pluginOptions.ignoreTagless !== false;
+  const ignoreStartWithNewLine = pluginOptions.ignoreStartWithNewLine !== false;
 
   return {
     TemplateLiteral (node) {
@@ -45,7 +46,11 @@ export default (context) => {
         return;
       }
 
-      const formatted = format(literal, context.options[1]);
+      let formatted = format(literal, context.options[1]);
+
+      if (ignoreStartWithNewLine && literal.startsWith('\n') && !formatted.startsWith('\n')) {
+        formatted = '\n' + formatted;
+      }
 
       if (formatted !== literal) {
         context.report({


### PR DESCRIPTION
## Overview

Adds an optional parameter to allow queries to start with new lines. Fixes https://github.com/gajus/eslint-plugin-sql/issues/5