### PR TITLE
fix: add support to nested property object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ after_success:
   - rm -fr ./dist
   - npm run build
   - semantic-release
+
+env:
+  - NPM_CONFIG_LEGACY_PEER_DEPS=true

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "main": "./dist/index.js",
   "name": "eslint-plugin-sql",
   "peerDependencies": {
-    "eslint": ">=6.8.0"
+    "eslint": ">=7.9.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "main": "./dist/index.js",
   "name": "eslint-plugin-sql",
   "peerDependencies": {
-    "eslint": ">=7.9.0"
+    "eslint": ">=6.8.0"
   },
   "repository": {
     "type": "git",

--- a/src/rules/noUnsafeQuery.js
+++ b/src/rules/noUnsafeQuery.js
@@ -35,7 +35,7 @@ export default (context) => {
       const legacyTagName = tag && tag.name && tag.name.toLowerCase();
       const tagName = tag && tag.property && tag.property.name && tag.property.name.toLowerCase();
 
-      if (legacyTagName !== 'sql' || tagName !== 'sql') {
+      if (legacyTagName !== 'sql' && tagName !== 'sql') {
         context.report({
           message: 'Use "sql" tag',
           node,

--- a/src/rules/noUnsafeQuery.js
+++ b/src/rules/noUnsafeQuery.js
@@ -31,8 +31,10 @@ export default (context) => {
       if (!recognizedAsQuery) {
         return;
       }
+      
+      const tagName = (node.parent.tag && node.parent.tag.name && node.parent.tag.name.toLowerCase()) || (node.parent.tag && node.parent.tag.property && node.parent.tag.property.name && node.parent.tag.property.name.toLowerCase())
 
-      if (!node.parent.tag || node.parent.tag.name.toLowerCase() !== 'sql') {
+      if (tagName !== 'sql') {
         context.report({
           message: 'Use "sql" tag',
           node,

--- a/src/rules/noUnsafeQuery.js
+++ b/src/rules/noUnsafeQuery.js
@@ -31,10 +31,11 @@ export default (context) => {
       if (!recognizedAsQuery) {
         return;
       }
-      
-      const tagName = (node.parent.tag && node.parent.tag.name && node.parent.tag.name.toLowerCase()) || (node.parent.tag && node.parent.tag.property && node.parent.tag.property.name && node.parent.tag.property.name.toLowerCase())
+      const tag = node.parent.tag;
+      const legacyTagName = tag && tag.name && tag.name.toLowerCase();
+      const tagName = tag && tag.property && tag.property.name && tag.property.name.toLowerCase();
 
-      if (tagName !== 'sql') {
+      if (legacyTagName !== 'sql' || tagName !== 'sql') {
         context.report({
           message: 'Use "sql" tag',
           node,


### PR DESCRIPTION
On new eslint versions the `name` property is nested, so added support for both old and new versions.