### PR TITLE
Fix missing files, fixes after TS migration

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,8 @@
 src
-tests
+bin
+!/dist/src
+test
 coverage
+*.tgz
 .*
 *.log

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ const rules = {
   'no-unsafe-query': noUnsafeQuery,
 };
 
-export default {
+export = {
   rules,
   rulesConfig: {
     format: 0,

--- a/src/rules/format.ts
+++ b/src/rules/format.ts
@@ -79,7 +79,7 @@ const create = (context) => {
   };
 };
 
-export default {
+export = {
   create,
   meta: {
     docs: {

--- a/src/rules/format.ts
+++ b/src/rules/format.ts
@@ -7,9 +7,7 @@ import {
 import isSqlQuery from '../utilities/isSqlQuery';
 
 const create = (context) => {
-  const {
-    placeholderRule,
-  } = context.settings.sql;
+  const placeholderRule = context.settings?.sql?.placeholderRule;
 
   const pluginOptions = context.options?.[0] || {};
 

--- a/src/rules/noUnsafeQuery.ts
+++ b/src/rules/noUnsafeQuery.ts
@@ -4,7 +4,7 @@ import isSqlQuery from '../utilities/isSqlQuery';
 const debug = createDebug('eslint-plugin-sql:rule:no-unsafe-query');
 
 export default (context) => {
-  const {placeholderRule} = context.settings.sql;
+  const placeholderRule = context.settings?.sql?.placeholderRule;
 
   const {allowLiteral} = context.options[0];
 
@@ -31,8 +31,8 @@ export default (context) => {
       }
 
       const {tag} = node.parent;
-      const legacyTagName = tag.name.toLowerCase();
-      const tagName = tag.property.name.toLowerCase();
+      const legacyTagName = tag?.name.toLowerCase();
+      const tagName = tag.property?.name.toLowerCase();
 
       if (legacyTagName !== 'sql' && tagName !== 'sql') {
         context.report({


### PR DESCRIPTION
this does essentially two things:
- fixes `.npmignore` so that it'll include files missing in v2.2.1 (https://github.com/gajus/eslint-plugin-sql/issues/19)
- fixes couple of errors I encountered after TypeScript migration