### PR TITLE
Correct pgformatter option to singular `keywordCase`

### DIFF
--- a/src/rules/format.ts
+++ b/src/rules/format.ts
@@ -135,7 +135,7 @@ export = {
             default: 'lowercase',
             type: 'string',
           },
-          keywordsCase: {
+          keywordCase: {
             default: 'lowercase',
             type: 'string',
           },


### PR DESCRIPTION
This configuration option should be singular, according to https://github.com/gajus/pg-formatter#configuration