### PR TITLE
feat: Add `matchIndentation` option

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,9 @@
 module.exports = {
   extends: ['canonical/auto', 'canonical/node'],
-  ignorePatterns: ['dist', 'package-lock.json'],
+  ignorePatterns: ['dist', 'package-lock.json', 'node_modules'],
   root: true,
   rules: {
+    'complexity': 0,
     'no-template-curly-in-string': 0,
     'node/no-sync': 0,
   },

--- a/src/utilities/indent.ts
+++ b/src/utilities/indent.ts
@@ -1,0 +1,48 @@
+type IndentOptions = {
+  includeEmptyLines?: boolean;
+  indent?: string;
+};
+
+const minIndent = function (string: string): number {
+  const match = string.match(/^[\t ]*(?=\S)/gmu);
+
+  if (!match) {
+    return 0;
+  }
+
+  let min = Number.POSITIVE_INFINITY;
+
+  for (const indent of match) {
+    min = Math.min(min, indent.length);
+  }
+
+  return min;
+};
+
+export const stripIndent = function (string: string): string {
+  const indent = minIndent(string);
+
+  if (indent === 0) {
+    return string;
+  }
+
+  const regex = new RegExp(`^[ \\t]{${indent}}`, 'gmu');
+
+  return string.replace(regex, '');
+};
+
+export const indentString = function (
+  string: string,
+  count: number = 1,
+  options: IndentOptions = {},
+): string {
+  const { indent = ' ', includeEmptyLines = false } = options;
+
+  if (count === 0) {
+    return string;
+  }
+
+  const regex = includeEmptyLines ? /^/gmu : /^(?!\s*$)/gmu;
+
+  return string.replace(regex, indent.repeat(count));
+};

--- a/test/rules/assertions/format.ts
+++ b/test/rules/assertions/format.ts
@@ -13,7 +13,7 @@ export default {
           ignoreTagless: false,
         },
       ],
-      output: '`\nSELECT\n    1\n`',
+      output: '`\n    SELECT\n        1\n`',
     },
     {
       code: '`SELECT 2`',
@@ -31,7 +31,7 @@ export default {
           spaces: 2,
         },
       ],
-      output: '`\nSELECT\n  2\n`',
+      output: '`\n  SELECT\n    2\n`',
     },
     {
       code: 'sql.unsafe`SELECT 3`',
@@ -45,7 +45,7 @@ export default {
           ignoreInline: false,
         },
       ],
-      output: 'sql.unsafe`\nSELECT\n    3\n`',
+      output: 'sql.unsafe`\n    SELECT\n        3\n`',
     },
     {
       code: 'sql.type()`SELECT 3`',
@@ -59,7 +59,7 @@ export default {
           ignoreInline: false,
         },
       ],
-      output: 'sql.type()`\nSELECT\n    3\n`',
+      output: 'sql.type()`\n    SELECT\n        3\n`',
     },
     {
       code: "`SELECT ${'foo'} FROM ${'bar'}`",
@@ -74,10 +74,132 @@ export default {
           ignoreTagless: false,
         },
       ],
-      output: "`\nSELECT\n    ${'foo'}\nFROM\n    ${'bar'}\n`",
+      output: "`\n    SELECT\n        ${'foo'}\n    FROM\n        ${'bar'}\n`",
+    },
+    {
+      code: "\t\t`SELECT ${'foo'} FROM ${'bar'}`",
+      errors: [
+        {
+          message: 'Format the query',
+        },
+      ],
+      options: [
+        {
+          ignoreInline: false,
+          ignoreTagless: false,
+        },
+      ],
+      output:
+        "\t\t`\n\t\t    SELECT\n\t\t        ${'foo'}\n\t\t    FROM\n\t\t        ${'bar'}\n\t\t`",
+    },
+    {
+      code: '\tconst s = sql`SELECT\n1\nFROM\ntable`',
+      errors: [
+        {
+          message: 'Format the query',
+        },
+      ],
+      options: [
+        {},
+        {
+          spaces: 2,
+        },
+      ],
+      output:
+        '\tconst s = sql`\n\t  SELECT\n\t    1\n\t  FROM\n\t    table\n\t`',
+    },
+    {
+      code: '\tconst s = sql`SELECT 1 FROM table`',
+      errors: [
+        {
+          message: 'Format the query',
+        },
+      ],
+      options: [
+        {
+          ignoreInline: false,
+        },
+        {
+          tabs: true,
+        },
+      ],
+      output:
+        '\tconst s = sql`\n\t\tSELECT\n\t\t\t1\n\t\tFROM\n\t\t\ttable\n\t`',
+    },
+    {
+      code: '\tconst s = sql`SELECT 1 FROM table`',
+      errors: [
+        {
+          message: 'Format the query',
+        },
+      ],
+      options: [
+        {
+          ignoreInline: false,
+        },
+        {
+          spaces: 0,
+          tabs: false,
+        },
+      ],
+      output:
+        '\tconst s = sql`\n\t    SELECT\n\t        1\n\t    FROM\n\t        table\n\t`',
+    },
+    {
+      code: '  const s = sql`SELECT 1 FROM table`',
+      errors: [
+        {
+          message: 'Format the query',
+        },
+      ],
+      options: [
+        {
+          ignoreInline: false,
+        },
+        {
+          spaces: 0,
+          tabs: false,
+        },
+      ],
+      output:
+        '  const s = sql`\n      SELECT\n          1\n      FROM\n          table\n  `',
+    },
+    {
+      code: '\tsql`SELECT 1 FROM table`',
+      errors: [
+        {
+          message: 'Format the query',
+        },
+      ],
+      options: [
+        {
+          ignoreInline: false,
+          matchIndentation: false,
+        },
+      ],
+      output: '\tsql`\nSELECT\n    1\nFROM\n    table`',
+    },
+    {
+      code: '\tconst query = sql`\nDELETE FROM table AS t\nWHERE t.id = ${foo}AND t.type = ${type};`',
+      errors: [
+        {
+          message: 'Format the query',
+        },
+      ],
+      options: [
+        {
+          ignoreInline: false,
+          matchIndentation: true,
+        },
+      ],
+      output:
+        '\tconst query = sql`\n\t    DELETE FROM table AS t\n\t    WHERE t.id = ${foo}\n\t        AND t.type = ${type};\n\t`',
     },
   ],
   valid: [
+    {
+      code: 'sql`SELECT 1`',
+    },
     {
       code: 'sql`SELECT 1`',
       options: [
@@ -101,6 +223,24 @@ export default {
           ignoreExpressions: true,
           ignoreInline: false,
           ignoreTagless: false,
+        },
+      ],
+    },
+    {
+      code: '\tconst s = sql`\n\t  SELECT\n\t    1\n\t  FROM\n\t    table\n\t`',
+      options: [
+        {},
+        {
+          spaces: 2,
+        },
+      ],
+    },
+    {
+      code: '\tconst query = sql`\n\t  DELETE FROM table AS t\n\t  WHERE t.id = ${foo}\n\t    AND t.type = ${type};\n\t`',
+      options: [
+        {},
+        {
+          spaces: 2,
         },
       ],
     },

--- a/test/rules/assertions/noUnsafeQuery.ts
+++ b/test/rules/assertions/noUnsafeQuery.ts
@@ -53,5 +53,8 @@ export default {
     {
       code: "sql`SELECT ${'foo'}`",
     },
+    {
+      code: 'sql``',
+    },
   ],
 };

--- a/test/utilities/indent.ts
+++ b/test/utilities/indent.ts
@@ -1,0 +1,58 @@
+/* global describe */
+/* global it */
+
+import { indentString, stripIndent } from '../../src/utilities/indent';
+import assert from 'node:assert';
+
+describe('indentString', () => {
+  it('should indent each line in a string', () => {
+    assert(indentString('foo\nbar') === ' foo\n bar');
+    assert(indentString('foo\nbar', 1) === ' foo\n bar');
+    assert(indentString('foo\r\nbar', 1) === ' foo\r\n bar');
+    assert(indentString('foo\nbar', 4) === '    foo\n    bar');
+  });
+  it('should not indent whitespace only lines', () => {
+    assert(indentString('foo\nbar\n', 1) === ' foo\n bar\n');
+    assert(
+      indentString('foo\nbar\n', 1, { includeEmptyLines: false }) ===
+        ' foo\n bar\n',
+    );
+  });
+  it('should indent every line if options.includeEmptyLines is true', () => {
+    assert(
+      indentString('foo\n\nbar\n\t', 1, { includeEmptyLines: true }) ===
+        ' foo\n \n bar\n \t',
+    );
+  });
+  it('should indent with leading whitespace', () => {
+    assert(
+      indentString('foo\n\nbar\n\t', 1, { includeEmptyLines: true }) ===
+        ' foo\n \n bar\n \t',
+    );
+  });
+  it('should indent with custom string', () => {
+    assert(indentString('foo\nbar\n', 1, { indent: '♥' }) === '♥foo\n♥bar\n');
+  });
+  it('should not indent when count is 0', () => {
+    assert(indentString('foo\nbar\n', 0) === 'foo\nbar\n');
+  });
+});
+
+describe('stripIndent', () => {
+  it('should strip leading whitespace from each line in a string', () => {
+    assert(stripIndent('') === '');
+    assert(stripIndent('\nunicorn\n') === '\nunicorn\n');
+    assert(stripIndent('\n  unicorn\n') === '\nunicorn\n');
+    assert(
+      stripIndent(
+        '\t\t<!doctype html>\n\t\t<html>\n\t\t\t<body>\n\n\n\n\t\t\t\t<h1>Hello world!</h1>\n\t\t\t</body>\n\t\t</html>',
+      ) ===
+        '<!doctype html>\n<html>\n\t<body>\n\n\n\n\t\t<h1>Hello world!</h1>\n\t</body>\n</html>',
+    );
+    assert(
+      stripIndent('\n\t\n\t\tunicorn\n\n\n\n\t\t\tunicorn') ===
+        '\n\t\nunicorn\n\n\n\n\tunicorn',
+      'ignore whitespace only lines',
+    );
+  });
+});

--- a/test/utilities/isSqlQuery.ts
+++ b/test/utilities/isSqlQuery.ts
@@ -15,4 +15,7 @@ describe('isSqlQuery', () => {
     assert(!isSqlQuery('foo bar'));
     assert(!isSqlQuery('foo SELECT FROM bar'));
   });
+  it('ignores falsy values', () => {
+    assert(!isSqlQuery(''));
+  });
 });


### PR DESCRIPTION
Closes: https://github.com/gajus/eslint-plugin-sql/issues/9

I see a few PRs for this issue, and all closed without being merged. I do not know the reasoning:
https://github.com/gajus/eslint-plugin-sql/pull/11
https://github.com/gajus/eslint-plugin-sql/pull/25
https://github.com/gajus/eslint-plugin-sql/pull/28

This PR makes the minimal required changes, includes logic from https://github.com/sindresorhus/indent-string, and adds unit tests, bringing coverage to almost complete (2 branches uncovered, and one is from a typedef).

<img width="583" alt="Screenshot 2023-06-08 at 12 07 29 PM" src="https://github.com/gajus/eslint-plugin-sql/assets/1943491/c5d4c17a-bb38-4142-8841-09b76db72d78">
