### PR TITLE
Fix doubling of new lines and adding indent ignore feature

### DIFF
--- a/.README/rules/format.md
+++ b/.README/rules/format.md
@@ -12,6 +12,7 @@ The first option is an object with the following configuration.
 
 |configuration|format|default|description|
 |---|---|---|---|
+|`ignoreBaseIndent`|boolean|`false`|Does not leave base indent before linting.|
 |`ignoreExpressions`|boolean|`false`|Does not format template literals that contain expressions.|
 |`ignoreInline`|boolean|`true`|Does not format queries that are written on a single line.|
 |`ignoreTagless`|boolean|`true`|Does not format queries that are written without using `sql` tag.|

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The first option is an object with the following configuration.
 
 |configuration|format|default|description|
 |---|---|---|---|
+|`ignoreBaseIndent`|boolean|`false`|Does not leave base indent before linting.|
 |`ignoreExpressions`|boolean|`false`|Does not format template literals that contain expressions.|
 |`ignoreInline`|boolean|`true`|Does not format queries that are written on a single line.|
 |`ignoreTagless`|boolean|`true`|Does not format queries that are written without using `sql` tag.|

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "debug": "^4.3.4",
     "lodash": "^4.17.21",
     "pg-formatter": "^2.0.2",
-    "sql-parse": "^0.1.5"
+    "sql-parse": "^0.1.5",
+    "strip-indent": "^3.0.0"
   },
   "description": "SQL linting rules for ESLint.",
   "devDependencies": {

--- a/src/rules/format.ts
+++ b/src/rules/format.ts
@@ -77,7 +77,7 @@ const create = (context) => {
                 node.quasis[0].range[0],
                 node.quasis[node.quasis.length - 1].range[1],
               ],
-              '`\n' + final + '`',
+              '`' + (final.startsWith('\n') ? final : '\n' + final) + '`',
             );
           },
           message: 'Format the query',

--- a/src/rules/format.ts
+++ b/src/rules/format.ts
@@ -1,6 +1,7 @@
 import isSqlQuery from '../utilities/isSqlQuery';
 import { generate } from 'astring';
 import { format } from 'pg-formatter';
+import stripIndent from 'strip-indent';
 
 const create = (context) => {
   const placeholderRule = context.settings?.sql?.placeholderRule;
@@ -11,6 +12,7 @@ const create = (context) => {
   const ignoreInline = pluginOptions.ignoreInline !== false;
   const ignoreTagless = pluginOptions.ignoreTagless !== false;
   const ignoreStartWithNewLine = pluginOptions.ignoreStartWithNewLine !== false;
+  const ignoreBaseIndent = pluginOptions.ignoreBaseIndent === true;
 
   return {
     TemplateLiteral(node) {
@@ -31,7 +33,7 @@ const create = (context) => {
 
       const magic = '"gajus-eslint-plugin-sql"';
 
-      const literal = node.quasis
+      let literal = node.quasis
         .map((quasi) => {
           return quasi.value.raw;
         })
@@ -43,6 +45,10 @@ const create = (context) => {
 
       if (ignoreInline && !literal.includes('\n')) {
         return;
+      }
+
+      if (ignoreBaseIndent) {
+        literal = stripIndent(literal);
       }
 
       let formatted = format(literal, context.options[1]);
@@ -101,6 +107,10 @@ export = {
       {
         additionalProperties: false,
         properties: {
+          ignoreBaseIndent: {
+            default: false,
+            type: 'boolean',
+          },
           ignoreExpressions: {
             default: false,
             type: 'boolean',

--- a/test/rules/assertions/format.ts
+++ b/test/rules/assertions/format.ts
@@ -76,6 +76,21 @@ export default {
       ],
       output: "`\nSELECT\n    ${'foo'}\nFROM\n    ${'bar'}\n`",
     },
+    {
+      code: "    const code = sql`\n    SELECT\n        ${'foo'}\n    FROM\n        ${'bar'}\n`",
+      errors: [
+        {
+          message: 'Format the query',
+        },
+      ],
+      options: [
+        {
+          ignoreBaseIndent: false,
+        },
+      ],
+      output:
+        "    const code = sql`\nSELECT\n    ${'foo'}\nFROM\n    ${'bar'}\n`",
+    },
   ],
   valid: [
     {
@@ -101,6 +116,14 @@ export default {
           ignoreExpressions: true,
           ignoreInline: false,
           ignoreTagless: false,
+        },
+      ],
+    },
+    {
+      code: "    const code = sql`\n    SELECT\n        ${'foo'}\n    FROM\n        ${'bar'}\n`",
+      options: [
+        {
+          ignoreBaseIndent: true,
         },
       ],
     },


### PR DESCRIPTION
9da5b349ba78ae55c9a4ef6227a742c3102c3e6d Fixes: https://github.com/gajus/eslint-plugin-sql/issues/10
**(because now it cause linting loop)**

`ignoreBaseIndent` makes this plugin usable with `unicorn/template-indent`  (or with  striptIndent template lit itself)
https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/template-indent.md **(because now it cause linting loop)**
that in some mind can close https://github.com/gajus/eslint-plugin-sql/pull/31 
