### PR TITLE
Fix last line strip indentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "astring": "^1.8.3",
         "debug": "^4.3.4",
+        "dedent": "^1.5.1",
         "lodash": "^4.17.21",
         "pg-formatter": "^2.0.2",
         "sql-parse": "^0.1.5"
@@ -4544,6 +4545,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/deep-equal": {
@@ -19433,6 +19447,12 @@
           "dev": true
         }
       }
+    },
+    "dedent": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "requires": {}
     },
     "deep-equal": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "dependencies": {
     "astring": "^1.8.3",
     "debug": "^4.3.4",
+    "dedent": "^1.5.1",
     "lodash": "^4.17.21",
     "pg-formatter": "^2.0.2",
-    "sql-parse": "^0.1.5",
-    "strip-indent": "^3.0.0"
+    "sql-parse": "^0.1.5"
   },
   "description": "SQL linting rules for ESLint.",
   "devDependencies": {

--- a/test/rules/assertions/format.ts
+++ b/test/rules/assertions/format.ts
@@ -120,7 +120,7 @@ export default {
       ],
     },
     {
-      code: "    const code = sql`\n    SELECT\n        ${'foo'}\n    FROM\n        ${'bar'}\n`",
+      code: "    const code = sql`\n    SELECT\n        ${'foo'}\n    FROM\n        ${'bar'}\n    `",
       options: [
         {
           ignoreBaseIndent: true,


### PR DESCRIPTION
In cont. of #33 
IgnoreBaseIndent feature incorrectly strip indent from last line of tagged template that causing infinity loop again.

Fix test and replace `strip-indent` -> `dedent` 

https://www.npmjs.com/package/dedent