### PR TITLE
fix: multiquery deindent

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -10,4 +10,3 @@ words:
   - gitdown
   - astring
   - quasis
-  - deindent

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "astring": "^1.8.3",
         "debug": "^4.3.4",
-        "deindent": "^0.1.0",
         "lodash": "^4.17.21",
         "pg-formatter": "^2.0.2",
         "sql-parse": "^0.1.5"
@@ -20,7 +19,6 @@
         "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/github": "^8.0.7",
         "@semantic-release/npm": "^10.0.3",
-        "@types/deindent": "^0.1.0",
         "@types/mocha": "^10.0.0",
         "@types/node": "^18.11.9",
         "cspell": "^6.31.1",
@@ -2626,12 +2624,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@types/deindent": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@types/deindent/-/deindent-0.1.0.tgz",
-      "integrity": "sha512-3by89NLVgO0itemyomWio5JoAKDYDtOuLtv562WVQZugsRWd7sjnI+4EaBzYGmN09nY0s5uVIrpM82/bAv+WqQ==",
-      "dev": true
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -4636,11 +4628,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/deindent": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/deindent/-/deindent-0.1.0.tgz",
-      "integrity": "sha512-3SOF3+jbGRpDrvZaojZJ5bfg6ubAfxmXcukRkX1Fd/pD2zK4J8uvADMAwnP0/4pwwwjHHRwsRYW5EkR/d6YAlQ=="
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -18015,12 +18002,6 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
     },
-    "@types/deindent": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@types/deindent/-/deindent-0.1.0.tgz",
-      "integrity": "sha512-3by89NLVgO0itemyomWio5JoAKDYDtOuLtv562WVQZugsRWd7sjnI+4EaBzYGmN09nY0s5uVIrpM82/bAv+WqQ==",
-      "dev": true
-    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -19519,11 +19500,6 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
-    },
-    "deindent": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/deindent/-/deindent-0.1.0.tgz",
-      "integrity": "sha512-3SOF3+jbGRpDrvZaojZJ5bfg6ubAfxmXcukRkX1Fd/pD2zK4J8uvADMAwnP0/4pwwwjHHRwsRYW5EkR/d6YAlQ=="
     },
     "delayed-stream": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "astring": "^1.8.3",
     "debug": "^4.3.4",
-    "deindent": "^0.1.0",
     "lodash": "^4.17.21",
     "pg-formatter": "^2.0.2",
     "sql-parse": "^0.1.5"
@@ -17,7 +16,6 @@
     "@semantic-release/commit-analyzer": "^9.0.2",
     "@semantic-release/github": "^8.0.7",
     "@semantic-release/npm": "^10.0.3",
-    "@types/deindent": "^0.1.0",
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.11.9",
     "cspell": "^6.31.1",

--- a/src/rules/format.ts
+++ b/src/rules/format.ts
@@ -1,6 +1,6 @@
+import dropBaseIndent from '../utilities/dropBaseIndent';
 import isSqlQuery from '../utilities/isSqlQuery';
 import { generate } from 'astring';
-import deindent from 'deindent';
 import { format } from 'pg-formatter';
 
 const create = (context) => {
@@ -48,7 +48,7 @@ const create = (context) => {
       }
 
       if (ignoreBaseIndent) {
-        literal = deindent(literal);
+        literal = dropBaseIndent(literal);
       }
 
       let formatted = format(literal, context.options[1]);
@@ -59,6 +59,10 @@ const create = (context) => {
         !formatted.startsWith('\n')
       ) {
         formatted = '\n' + formatted;
+      }
+
+      if (formatted.endsWith('\n\n')) {
+        formatted = formatted.replace(/\n\n$/u, '\n');
       }
 
       if (formatted !== literal) {

--- a/src/utilities/dropBaseIndent.ts
+++ b/src/utilities/dropBaseIndent.ts
@@ -1,0 +1,12 @@
+// based on https://github.com/sindresorhus/strip-indent
+export default (raw: string) => {
+  const trimmedString = raw.replace(/ *$/u, '');
+
+  const matches = trimmedString.match(/^[\t ]*(?=\S)/gmu);
+  if (!matches) return trimmedString;
+
+  const indent = Math.min(...matches.map((match) => match.length));
+  if (!indent) return trimmedString;
+
+  return trimmedString.replaceAll(new RegExp(`^[ \\t]{${indent}}`, 'gmu'), '');
+};

--- a/test/rules/assertions/format.ts
+++ b/test/rules/assertions/format.ts
@@ -135,5 +135,13 @@ export default {
         },
       ],
     },
+    {
+      code: '   const code = sql`\n        DROP TABLE foo;\n\n        DROP TABLE foo;\n    `;',
+      options: [
+        {
+          ignoreBaseIndent: true,
+        },
+      ],
+    },
   ],
 };


### PR DESCRIPTION
Dropped any external libs for deindentation.

Fixed deindentaion of multiple queries in one tag template. 
Fixed doubling of ending with doubling new lines if query ending with semicolon. 